### PR TITLE
Fixed import for VerifyChallengeMessage + information

### DIFF
--- a/src/Requests/VerifyChallengeRequest.php
+++ b/src/Requests/VerifyChallengeRequest.php
@@ -2,7 +2,7 @@
 namespace NicklasW\PkmGoApi\Requests;
 
 use POGOProtos\Networking\Envelopes\ResponseEnvelope;
-use POGOProtos\Networking\Requests\Messages\VerifyChallenge;
+use POGOProtos\Networking\Requests\Messages\VerifyChallengeMessage;
 use POGOProtos\Networking\Requests\RequestType;
 use POGOProtos\Networking\Responses\VerifyChallengeResponse;
 use ProtobufMessage;


### PR DESCRIPTION
I did some testing and succeeded to send back the token, this is just a small bug I've found in your code. The classname is _VerifyChallengeMessage_, though the filename is _VerifyChallenge_. This is an error in the protos repo, I've opened an issue already (https://github.com/NicklasWallgren/pogoprotos-php/issues/10). But the import should be on the classname in order to work.

I managed to send it back using this logic:

``` php
$config = new Config();
// TODO: Set Auth-Info to Config

// Create the authentication manager
$manager = Factory::create($config);

// Initialize the pokemon go application
$application = new ApplicationKernel($manager);
$pogoApi = $application->getPokemonGoApi();
$requestHandler = $pogoApi->getRequestService()->requestHandler();

$verifyChallenge = new \NicklasW\PkmGoApi\Requests\VerifyChallengeRequest($token);

$response = $requestHandler->handle($verifyChallenge);
```

Now someone has to put this nicely into the library :laughing:.

Note that the response HTTP code is always _200_, and the ResponseEnvelope StatusCode is `OK`, but if the token is rejected the _returns_ field is empty (**not** a `false` bool), so you get this error:

```
Fatal error: Uncaught InvalidArgumentException: fp must be a string or file resource in vendor\nicklasw\pogoprotos-php\src\protocolbuffers.inc.php:37
Stack trace:
#0 vendor\nicklasw\pogoprotos-php\src\protocolbuffers.inc.php(54): checkArgument
(false, 'fp must be a st...')
#1 vendor\nicklasw\pogoprotos-php\src\POGOProtos\Networking\Responses\VerifyChal
lengeResponse.php(24): ProtobufIO::toStream(NULL, 9223372036854775807)
#2 src\Requests\VerifyChallengeRequest.php(71): POGOProtos\Networking\Responses\
VerifyChallengeResponse->read(NULL)
```

We'd have to find a way to deal with this aswell.

I hope these information help you somehow.

See also https://github.com/AeonLucid/POGOProtos/issues/240
